### PR TITLE
feat: casual and party mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ A service to sync your [Philips Wiz lights](https://www.wizconnected.com/) to pl
 
 If your Spotify music is playing, your lights should automatically change color to each beat synchronously. You can play with the app by pausing the music, changing the track, etc. If you stop the music completely, then the API call needs to be made again. This is done to preserve API rate limits and achieve efficiency.
 
+### Party Mode
+
+* This app also has a party mode that takes the effect up a notch by changing the lights more aggressively and alternating between the lowest and highest brightness levels. To run the app in party mode, all you have to do is pass another query string in the URL called `mode` and set it to `party`. For e.g., "[http://localhost:8888/dance-to-spotify?roomIds=6931115&mode=party](http://localhost:8888/dance-to-spotify?roomIds=6931115&mode=party)".
+
+<strong>Warning</strong>: This is not for everyone as the lights change rapidly and alternate between lowest and the highest brightness levels. If you feel nauseous or uncomfortable, please stop using this mode.
+
 <strong>Note</strong>: If you run into any issues, run the app in debug mode (`npm run start debug`) to determine the cause. If you prefer getting the debug logs in a file, you can run (`npm run start debug file`).
 
 Hope you have fun! Thanks for checking out this repo! 😁

--- a/src/handlers/route-handlers/dance-to-spotify-router.ts
+++ b/src/handlers/route-handlers/dance-to-spotify-router.ts
@@ -57,8 +57,10 @@ danceToSpotifyRouter.get('/dance-to-spotify', async (req: Request) => {
       roomIds = Object.keys(<never>cacheManager.get('rooms'));
     }
 
+    const isPartyMode = req.query.mode === 'party';
+
     await listenToDanceToSpotifyEvent(roomIds);
-    await emitDanceToSpotifyEvent();
+    await emitDanceToSpotifyEvent(isPartyMode);
 
     cacheManager.set('instance', 'stopped');
   } catch (err: any) {


### PR DESCRIPTION
Some individuals might find the previous way of syncing lights too aggressive. This PR fundamentally changes how lights behave by making the default mode to change lights with a 2x delay and only alternate between 0.5x and 1x brightnesses. 

For those who want to enjoy the previous way, that still option is still present and they can do so by running the app in party mode.

Thanks to Reddit User (@volibearrox) for making the suggestion.